### PR TITLE
JWT 발급 및 검증 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 	
 	runtimeOnly 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
-	
+	testAnnotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/github/hojoungjang/spring_login_examples/config/TokenAuthenticationFilter.java
+++ b/src/main/java/com/github/hojoungjang/spring_login_examples/config/TokenAuthenticationFilter.java
@@ -29,7 +29,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
         String token = getAccessToken(authorizationHeader);
         
-        if (tokenProvider.validToken(token)) {
+        if (tokenProvider.validateToken(token)) {
             Authentication authentication = tokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/com/github/hojoungjang/spring_login_examples/config/TokenAuthenticationFilter.java
+++ b/src/main/java/com/github/hojoungjang/spring_login_examples/config/TokenAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.github.hojoungjang.spring_login_examples.config;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.github.hojoungjang.spring_login_examples.config.jwt.TokenProvider;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+    private final TokenProvider tokenProvider;
+    private final static String HEADER_AUTHORIZATION = "Authorization";
+    private final static String TOKEN_PREFIX = "Bearer";
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
+        String token = getAccessToken(authorizationHeader);
+        
+        if (tokenProvider.validToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getAccessToken(String authorizationHeader) {
+        if (authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
+            return authorizationHeader.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/github/hojoungjang/spring_login_examples/config/jwt/JwtProperties.java
+++ b/src/main/java/com/github/hojoungjang/spring_login_examples/config/jwt/JwtProperties.java
@@ -1,0 +1,16 @@
+package com.github.hojoungjang.spring_login_examples.config.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Component
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+    private String issuer;
+    private String secretKey;
+}

--- a/src/main/java/com/github/hojoungjang/spring_login_examples/config/jwt/TokenProvider.java
+++ b/src/main/java/com/github/hojoungjang/spring_login_examples/config/jwt/TokenProvider.java
@@ -1,0 +1,75 @@
+package com.github.hojoungjang.spring_login_examples.config.jwt;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import com.github.hojoungjang.spring_login_examples.domain.User;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class TokenProvider {
+    private final JwtProperties jwtProperties;
+
+    public String generateToken(User user, Duration expiredAt) {
+        Date expiry = new Date((new Date()).getTime() + expiredAt.toMillis());
+        return makeToken(expiry, user);
+    }
+
+    private String makeToken(Date expiry, User user) {
+        Date now = new Date();
+        return Jwts.builder()
+            .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+            .setIssuer(jwtProperties.getIssuer())
+            .setIssuedAt(now)
+            .setExpiration(expiry)
+            .setSubject(user.getEmail())
+            .claim("id", user.getId())
+            .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+            .compact();
+    }
+
+    public boolean validToken(String token) {
+        try {
+            Jwts.parser()
+                .setSigningKey(jwtProperties.getSecretKey())
+                .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = getClaims(token);
+        Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
+
+        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails.User(
+            claims.getSubject(), "", authorities
+        ), token, authorities);
+    }
+
+    public Long getUserId(String token) {
+        Claims claims = getClaims(token);
+        return claims.get("id", Long.class);
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+            .setSigningKey(jwtProperties.getSecretKey())
+            .parseClaimsJws(token)
+            .getBody();
+    }
+}

--- a/src/main/java/com/github/hojoungjang/spring_login_examples/config/jwt/TokenProvider.java
+++ b/src/main/java/com/github/hojoungjang/spring_login_examples/config/jwt/TokenProvider.java
@@ -23,12 +23,8 @@ import lombok.RequiredArgsConstructor;
 public class TokenProvider {
     private final JwtProperties jwtProperties;
 
-    public String generateToken(User user, Duration expiredAt) {
-        Date expiry = new Date((new Date()).getTime() + expiredAt.toMillis());
-        return makeToken(expiry, user);
-    }
-
-    private String makeToken(Date expiry, User user) {
+    public String generateToken(User user, Duration expiryOffset) {
+        Date expiry = new Date((new Date()).getTime() + expiryOffset.toMillis());
         Date now = new Date();
         return Jwts.builder()
             .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
@@ -41,7 +37,7 @@ public class TokenProvider {
             .compact();
     }
 
-    public boolean validToken(String token) {
+    public boolean validateToken(String token) {
         try {
             Jwts.parser()
                 .setSigningKey(jwtProperties.getSecretKey())

--- a/src/main/java/com/github/hojoungjang/spring_login_examples/controller/TokenApiController.java
+++ b/src/main/java/com/github/hojoungjang/spring_login_examples/controller/TokenApiController.java
@@ -1,0 +1,31 @@
+package com.github.hojoungjang.spring_login_examples.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+import com.github.hojoungjang.spring_login_examples.dto.CreateAccessTokenRequest;
+import com.github.hojoungjang.spring_login_examples.dto.CreateAccessTokenResponse;
+import com.github.hojoungjang.spring_login_examples.service.TokenService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+
+@RequiredArgsConstructor
+@RestController
+public class TokenApiController {
+    private final TokenService tokenService;
+
+    @PostMapping("/api/token")
+    public ResponseEntity<CreateAccessTokenResponse> createNewAccessToken(
+        @RequestBody CreateAccessTokenRequest request
+    ) {
+        String newAccessToken = tokenService.createNewAccessToken(request.getRefreshToken());
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(new CreateAccessTokenResponse(newAccessToken));
+    }
+    
+}

--- a/src/main/java/com/github/hojoungjang/spring_login_examples/domain/RefreshToken.java
+++ b/src/main/java/com/github/hojoungjang/spring_login_examples/domain/RefreshToken.java
@@ -1,0 +1,35 @@
+package com.github.hojoungjang.spring_login_examples.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, unique = true)
+    private Long userId;
+
+    @Column(name = "refresh_token", nullable = false)
+    private String refreshToken;
+
+    public RefreshToken(Long userId, String refreshToken) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+    }
+
+    public RefreshToken update(String newRefreshToken) {
+        this.refreshToken = newRefreshToken;
+        return this;
+    }
+}

--- a/src/main/java/com/github/hojoungjang/spring_login_examples/dto/CreateAccessTokenRequest.java
+++ b/src/main/java/com/github/hojoungjang/spring_login_examples/dto/CreateAccessTokenRequest.java
@@ -1,0 +1,10 @@
+package com.github.hojoungjang.spring_login_examples.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateAccessTokenRequest {
+    private String refreshToken;
+}

--- a/src/main/java/com/github/hojoungjang/spring_login_examples/dto/CreateAccessTokenResponse.java
+++ b/src/main/java/com/github/hojoungjang/spring_login_examples/dto/CreateAccessTokenResponse.java
@@ -1,0 +1,10 @@
+package com.github.hojoungjang.spring_login_examples.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CreateAccessTokenResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/github/hojoungjang/spring_login_examples/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/github/hojoungjang/spring_login_examples/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.github.hojoungjang.spring_login_examples.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.github.hojoungjang.spring_login_examples.domain.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUserId(Long userId);
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/github/hojoungjang/spring_login_examples/service/RefreshTokenService.java
+++ b/src/main/java/com/github/hojoungjang/spring_login_examples/service/RefreshTokenService.java
@@ -1,0 +1,19 @@
+package com.github.hojoungjang.spring_login_examples.service;
+
+import org.springframework.stereotype.Service;
+
+import com.github.hojoungjang.spring_login_examples.domain.RefreshToken;
+import com.github.hojoungjang.spring_login_examples.repository.RefreshTokenRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepo;
+
+    public RefreshToken findByRefreshToken(String refreshToken) {
+        return refreshTokenRepo.findByRefreshToken(refreshToken)
+            .orElseThrow(() -> new IllegalArgumentException("Unexpected token"));
+    }
+}

--- a/src/main/java/com/github/hojoungjang/spring_login_examples/service/TokenService.java
+++ b/src/main/java/com/github/hojoungjang/spring_login_examples/service/TokenService.java
@@ -1,0 +1,29 @@
+package com.github.hojoungjang.spring_login_examples.service;
+
+import java.time.Duration;
+
+import org.springframework.stereotype.Service;
+
+import com.github.hojoungjang.spring_login_examples.config.jwt.TokenProvider;
+import com.github.hojoungjang.spring_login_examples.domain.User;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class TokenService {
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final UserService userService;
+
+    public String createNewAccessToken(String refreshToken) {
+        if (!tokenProvider.validToken(refreshToken)) {
+            throw new IllegalArgumentException("Unexpected token");
+        }
+
+        Long userId = refreshTokenService.findByRefreshToken(refreshToken).getUserId();
+        User user = userService.findById(userId);
+
+        return tokenProvider.generateToken(user, Duration.ofHours(2));
+    }
+}

--- a/src/main/java/com/github/hojoungjang/spring_login_examples/service/TokenService.java
+++ b/src/main/java/com/github/hojoungjang/spring_login_examples/service/TokenService.java
@@ -17,7 +17,7 @@ public class TokenService {
     private final UserService userService;
 
     public String createNewAccessToken(String refreshToken) {
-        if (!tokenProvider.validToken(refreshToken)) {
+        if (!tokenProvider.validateToken(refreshToken)) {
             throw new IllegalArgumentException("Unexpected token");
         }
 

--- a/src/main/java/com/github/hojoungjang/spring_login_examples/service/UserService.java
+++ b/src/main/java/com/github/hojoungjang/spring_login_examples/service/UserService.java
@@ -20,6 +20,10 @@ public class UserService {
             .email(request.getEmail())
             .password(passwordEncoder.encode(request.getPassword()))
             .build()).getId();
-            
+    }
+
+    public User findById(Long userId) {
+        return userRepo.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("Unexpected user"));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,0 @@
-spring.application.name=spring-login-examples
-
-spring.datasource.url=jdbc:h2:mem:testdb
-
-spring.h2.console.enabled=true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  application:
+    name: spring-login-examples
+
+  datasource:
+    url: jdbc:h2:mem:testdb
+
+  h2:
+    console:
+      enabled: true
+
+jwt:
+  issuer: springadmin@example.com
+  secret_key: study-springboot

--- a/src/test/java/com/github/hojoungjang/spring_login_examples/config/jwt/JwtFactory.java
+++ b/src/test/java/com/github/hojoungjang/spring_login_examples/config/jwt/JwtFactory.java
@@ -1,0 +1,45 @@
+package com.github.hojoungjang.spring_login_examples.config.jwt;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.Builder;
+import lombok.Getter;
+
+import static java.util.Collections.emptyMap;
+
+@Getter
+public class JwtFactory {
+    private String subject = "test@email.com";
+    private Date issuedAt = new Date();
+    private Date expiration = new Date(new Date().getTime() + Duration.ofDays(14).toMillis());
+    private Map<String, Object> claims = emptyMap();
+
+    @Builder
+    public JwtFactory(String subject, Date issuedAt, Date expiration, Map<String, Object> claims) {
+        this.subject = subject != null ? subject : this.subject;
+        this.issuedAt = issuedAt != null ? issuedAt : this.issuedAt;
+        this.expiration = expiration != null ? expiration : this.expiration;
+        this.claims = claims != null ? claims : this.claims;
+    }
+
+    public static JwtFactory withDefaultValues() {
+        return JwtFactory.builder().build();
+    }
+
+    public String createToken(JwtProperties jwtProperties) {
+        return Jwts.builder()
+            .setSubject(subject)
+            .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+            .setIssuer(jwtProperties.getIssuer())
+            .setIssuedAt(issuedAt)
+            .setExpiration(expiration)
+            .addClaims(claims)
+            .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+            .compact();
+    }
+}

--- a/src/test/java/com/github/hojoungjang/spring_login_examples/config/jwt/TokenProviderTest.java
+++ b/src/test/java/com/github/hojoungjang/spring_login_examples/config/jwt/TokenProviderTest.java
@@ -49,26 +49,26 @@ public class TokenProviderTest {
         assertThat(userId).isEqualTo(testUser.getId());
     }
 
-    @DisplayName("validToken(): 만료된 토큰인 경우에 유효성 검증에 실패한다.")
+    @DisplayName("validateToken(): 만료된 토큰인 경우에 유효성 검증에 실패한다.")
     @Test
-    void validToken_invalidToken() {
+    void validateToken_invalidateToken() {
         // given
         String token = JwtFactory.builder()
             .expiration(new Date(new Date().getTime() - Duration.ofDays(7).toMillis()))
             .build()
             .createToken(jwtProperties);
 
-        boolean result = tokenProvider.validToken(token);
+        boolean result = tokenProvider.validateToken(token);
         assertThat(result).isFalse();
     }
 
-    @DisplayName("validToken(): 유효한 토큰인 경우에 유효성 검증에 성공한다.")
+    @DisplayName("validateToken(): 유효한 토큰인 경우에 유효성 검증에 성공한다.")
     @Test
-    void validToken_validToken() {
+    void validateToken_validateToken() {
         //given
         String token = JwtFactory.withDefaultValues().createToken(jwtProperties);
 
-        boolean result = tokenProvider.validToken(token);
+        boolean result = tokenProvider.validateToken(token);
 
         assertThat(result).isTrue();
     }

--- a/src/test/java/com/github/hojoungjang/spring_login_examples/config/jwt/TokenProviderTest.java
+++ b/src/test/java/com/github/hojoungjang/spring_login_examples/config/jwt/TokenProviderTest.java
@@ -1,0 +1,103 @@
+package com.github.hojoungjang.spring_login_examples.config.jwt;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.github.hojoungjang.spring_login_examples.domain.User;
+import com.github.hojoungjang.spring_login_examples.repository.UserRepository;
+
+import io.jsonwebtoken.Jwts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class TokenProviderTest {
+    @Autowired
+    private TokenProvider tokenProvider;
+    @Autowired
+    private UserRepository userRepo;
+    @Autowired
+    private JwtProperties jwtProperties;
+
+    @DisplayName("generateToken(): 유저 정보와 만료 기간을 전달해 토큰을 만들 수 있다.")
+    @Test
+    void generateToken() {
+        // given
+        User testUser = userRepo.save(User.builder()
+            .email("user@gmail.com")
+            .password("test")
+            .build());
+        
+        // when
+        String token = tokenProvider.generateToken(testUser, Duration.ofDays(14));
+
+        // then
+        Long userId = Jwts.parser()
+            .setSigningKey(jwtProperties.getSecretKey())
+            .parseClaimsJws(token)
+            .getBody()
+            .get("id", Long.class);
+        
+        assertThat(userId).isEqualTo(testUser.getId());
+    }
+
+    @DisplayName("validToken(): 만료된 토큰인 경우에 유효성 검증에 실패한다.")
+    @Test
+    void validToken_invalidToken() {
+        // given
+        String token = JwtFactory.builder()
+            .expiration(new Date(new Date().getTime() - Duration.ofDays(7).toMillis()))
+            .build()
+            .createToken(jwtProperties);
+
+        boolean result = tokenProvider.validToken(token);
+        assertThat(result).isFalse();
+    }
+
+    @DisplayName("validToken(): 유효한 토큰인 경우에 유효성 검증에 성공한다.")
+    @Test
+    void validToken_validToken() {
+        //given
+        String token = JwtFactory.withDefaultValues().createToken(jwtProperties);
+
+        boolean result = tokenProvider.validToken(token);
+
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("getAuthentication(): 토큰 기반으로 인증정보를 가져올 수 있다.")
+    @Test
+    void getAuthentication() {
+        String userEmail = "user@email.com";
+        String token = JwtFactory.builder()
+            .subject(userEmail)
+            .build()
+            .createToken(jwtProperties);
+
+        Authentication authentication = tokenProvider.getAuthentication(token);
+
+        assertThat(((UserDetails) authentication.getPrincipal()).getUsername()).isEqualTo(userEmail);
+    }
+
+    @DisplayName("getUserId(): 토큰으로 유저 ID를 가져올 수 있다.")
+    @Test
+    void getUerId() {
+        Long userId = 1L;
+        String token = JwtFactory.builder()
+            .claims(Map.of("id", userId))
+            .build()
+            .createToken(jwtProperties);
+
+        Long userIdByToken = tokenProvider.getUserId(token);
+
+        assertThat(userIdByToken).isEqualTo(userId);
+    }
+}

--- a/src/test/java/com/github/hojoungjang/spring_login_examples/controller/TokenApiControllerTest.java
+++ b/src/test/java/com/github/hojoungjang/spring_login_examples/controller/TokenApiControllerTest.java
@@ -1,0 +1,81 @@
+package com.github.hojoungjang.spring_login_examples.controller;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.hojoungjang.spring_login_examples.config.jwt.JwtFactory;
+import com.github.hojoungjang.spring_login_examples.config.jwt.JwtProperties;
+import com.github.hojoungjang.spring_login_examples.domain.RefreshToken;
+import com.github.hojoungjang.spring_login_examples.domain.User;
+import com.github.hojoungjang.spring_login_examples.dto.CreateAccessTokenRequest;
+import com.github.hojoungjang.spring_login_examples.repository.RefreshTokenRepository;
+import com.github.hojoungjang.spring_login_examples.repository.UserRepository;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class TokenApiControllerTest {
+    @Autowired
+    protected MockMvc mockMvc;
+    @Autowired
+    protected ObjectMapper objectMapper;
+    @Autowired
+    private WebApplicationContext context;
+    @Autowired
+    JwtProperties jwtProperties;
+    @Autowired
+    UserRepository userRepo;
+    @Autowired
+    RefreshTokenRepository refreshTokenRepo;
+
+    @BeforeEach
+    public void mockMvcSetup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+        userRepo.deleteAll();
+    }
+
+    @DisplayName("createNewAccessToken: 새로운 엑세스 토큰을 발급한다.")
+    @Test
+    public void createNewAccessToken() throws Exception {
+        // given
+        final String url = "/api/token";
+        User testUser = userRepo.save(User.builder()
+            .email("user@gmail.com")
+            .password("test")
+            .build());
+        String refreshToken = JwtFactory.builder()
+            .claims(Map.of("id", testUser.getId()))
+            .build()
+            .createToken(jwtProperties);
+        refreshTokenRepo.save(new RefreshToken(testUser.getId(), refreshToken));
+
+        CreateAccessTokenRequest request = new CreateAccessTokenRequest();
+        request.setRefreshToken(refreshToken);
+        final String requestBody = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post(url)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(requestBody));
+
+        // then
+        resultActions
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.accessToken").isNotEmpty());
+    }
+}


### PR DESCRIPTION
# JWT 정의
JSON Web Token 은 데이터를 통신할때 사용되는 데이터 포멧 기준
오늘날처럼 유저의 인증정보를 담는 목표로 만들어졌다기 보다는 일반적으로 아무 데이터에 대한 통신을 명세하는 표준이다.

#### JWT vs JWS vs JWE
JWT 는 기준을 명세하는 인터페이스 같은 것
JWS 와 JWE 는 JWT 를 구현하는 방식
보통 우리가 아는 JWT 는 JWS 이다. 
JWS 는 서명부분이 추가된다. 따라서 헤더와 payload  그리고 둘을 서명한 결과가 합쳐진게 된다 (헤더 + payload + 서명(헤더 + payload))

### 구조
#### header
보통 토큰의 종류와 서명 방식을 상세한다

#### payload
여러 클레임 (데이터) 가 들어가 있다.
registered claim, public 그리고 private claim 으로 나뉜다.
registered claim 은 JWT 표준 자체에서 정의하는 클레임들이다.
public 하고 private 클레임은 둘다 커스텀 클레임인데 public 은 추가적으로 만들어진 표준 클레임 네임스페이스이다. [registry](https://www.iana.org/assignments/jwt/jwt.xhtml) 가 따로 있다.
private 클레임은 어플리케이션 개발자가 임의로 추가하는 그외 모든 클레임이다. public 클레임 이름과 겹치지 않게 작성하는게 best practice 이다.

#### signature
header 와 payload 데이터를 서명해서 추후 토큰의 무결성 (integrity) 를 검증할 때 사용한다.

# 순서
1. JWT 생성 및 검증하는 `TokenProvider` 추가
2. Refresh token 데이터 모델 추가
3. 토큰 필터 추가
4. refresh token 기반으로 새로운 토큰 발급을 위한 service 빈 추가
5. refresh token 기반으로 새로운 토큰 발급을 위한 controller 추가

# `TokenProvider` 추가
`jjwt` - Java JWT 라이브러리 사용하기

## 토큰 만들기
토큰을 만들때는 보통 헤더에 데이터 추가, 지정된 클레임 추가 (registered claims), 필요한 커스텀 클레임 추가, 서명, 압축 호출의 chaining 식으로 작성한다.

```java
return Jwts.builder()
            .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
            .setIssuer(jwtProperties.getIssuer())
            .setIssuedAt(now)
            .setExpiration(expiry)
            .setSubject(user.getEmail())
            .claim("id", user.getId())
            .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
            .compact();
```

## 검증하기
parser 와 서명할때 사용된 키 (symmetric key 일 경우) 를 사용해서 아래와 같이 토큰 유효성 검사.

```java
Jwts.parser()
    .setSigningKey(jwtProperties.getSecretKey())
    .parseClaimsJws(token)
```

# Refresh token 데이터 모델 추가
각 레코드는 id, refresh token, user ID 갖는다.
Refresh token 에 대한 정보는 서버에서 가지고 있어야 추후 토큰 재발급때 유효성을 검사 할 수 있다.

# 토큰 필터 추가
아직은 정확히 어떻게 쓰는지 모르겠지만 미들웨어 또는 aspect 처럼 각 요청을 처리하기 전에 해당 요청의 들어온 헤더에서 `Authorizaiton` 필드의 저장된 토큰 값의 유효성 검사하고 해당 토큰 클레임에 들어있는 유저 정보를 사용해 `SecurityContextHolder` 에 넣어준다.

`OncePerRequestFilter` 를 상속 받아 `doFilterInternal()` 메서드를 오버라이드 한다.

```java
public class TokenAuthenticationFilter extends OncePerRequestFilter {
    // ...
    @Override
    protected void doFilterInternal(
        HttpServletRequest request,
        HttpServletResponse response,
        FilterChain filterChain
    ) {
         // ...
    }
    // ...
}
```
# refresh token 기반으로 새로운 토큰 발급
이부분에서 테스트 코드를 보면 JWT 발급하는 방식과 같은 방식으로 refresh token 을 발급하는데 그부분은 원래 JWT 표준상으로도 그런지 의문이다.